### PR TITLE
Appveyor: fix builds with rustup

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,21 +1,18 @@
 environment:
   matrix:
-  - TARGET: x86_64-pc-windows-gnu
-    MSYS_BITS: 64
-  - TARGET: i686-pc-windows-gnu
-    MSYS_BITS: 32
   - TARGET: x86_64-pc-windows-msvc
   - TARGET: i686-pc-windows-msvc
 install:
-  - ps: Start-FileDownload "https://static.rust-lang.org/dist/rust-nightly-${env:TARGET}.exe"
-  - rust-nightly-%TARGET%.exe /VERYSILENT /NORESTART /DIR="C:\Program Files (x86)\Rust"
-  - set PATH=%PATH%;C:\Program Files (x86)\Rust\bin
-  - if defined MSYS_BITS set PATH=%PATH%;C:\msys64\mingw%MSYS_BITS%\bin;C:\msys64\usr\bin
+  - curl https://win.rustup.rs/ > rustup-init.exe
+  - rustup-init.exe -y --default-host %TARGET%
+  - set PATH=%PATH%;C:\Users\appveyor\.cargo\bin
   - set CARGO_TARGET_DIR=%APPVEYOR_BUILD_FOLDER%\target
   - rustc -V
   - cargo -V
 
-build: false
+build_script:
+  - cargo build --release
 
-test_script:
-  - cargo build --target %TARGET%
+artifacts:
+  - path: target/release/git-submerge.exe
+    name: git-submerge


### PR DESCRIPTION
### Platforms

Finally I've decided to concentrate only on MSVC (both x32 and x64), because there were some problems with gcc toolchain on Appveyor (and I haven't tried it on my own machine).

### Artifacts

We're building the *release* artifacts for both x32 and x64 MSVC compilers, and it should be okay for the users. You could download them from Appveyor and publish on the project releases page.

I have also verified that the artifacts have correct bitness and that they're executable.

### Caching

Finally I've decided that there's nothing to cache in our project. The rustup download, and the registry update seem to be quick enough, and I don't want to cache the `target` directory (that contain the built dependency artifacts).

### Issues

Closes #14.